### PR TITLE
Handle timing issues and note updates

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -7,12 +7,20 @@
 
 class Shadow {
   constructor (domNode) {
+    this.buttons = []
     this.domNode = domNode
     this.tag = '@shadow'
   }
 
   setShadows (nodes) {
-    for (let node of nodes) {
+    let i = 0
+    const interval = setInterval(() => {
+      if (i === nodes.length) {
+        clearInterval(interval)
+        return
+      }
+
+      const node = nodes[i++]
       const icon = node.querySelector('.icon')
       icon.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }))
       if (this.domNode.querySelector('.tooltip').textContent.toLowerCase().includes(this.tag)) {
@@ -20,7 +28,20 @@ class Shadow {
         node.classList.remove('gray', 'orange', 'red', 'green', 'aqua', 'blue', 'purple', 'magenta')
       }
       icon.dispatchEvent(new MouseEvent('mouseout', { bubbles: true }))
-    }
+    }, 100)
+  }
+
+  updateListener () {
+    this.setShadows(document.querySelectorAll('.has-notes'))
+  }
+
+  addUpdateListeners (buttons) {
+    buttons.forEach(button => {
+      if (!this.buttons.includes(button)) {
+        this.buttons.push(button)
+        button.addEventListener('click', this.updateListener.bind(this))
+      }
+    })
   }
 
   observe () {
@@ -32,6 +53,14 @@ class Shadow {
         return nodes
       }, [])
       this.setShadows(nodes)
+
+      const buttons = mutations.filter((mutation) => {
+        return mutation.type === 'childList' && [...mutation.target.classList].includes('test-submit')
+      }).reduce((buttons, mutation) => {
+        buttons.push(mutation.target)
+        return buttons
+      }, [])
+      this.addUpdateListeners(buttons)
     }).observe(this.domNode, {
       childList: true,
       subtree: true


### PR DESCRIPTION
When a node is updated from fx 'blah' to '@shadow', it would not be reflected in the shading. I am adding an event handler that will help with that.

The event handler is crude, because there is no mapping between a note and the button, we have to iterate all visible notes, to see if the should have shading.

Also, we get the note from an item by dispatching e mouse event. This is slow, so we need to wrap all those events in a timer. It is the best we can do other than iterating all nodes again.